### PR TITLE
feat: add Keycloak database persistence with PostgreSQL

### DIFF
--- a/k8s/base/keycloak/database.yaml
+++ b/k8s/base/keycloak/database.yaml
@@ -1,0 +1,82 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-postgres
+spec:
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+  selector:
+    app: keycloak-postgres
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: keycloak-postgres
+spec:
+  serviceName: keycloak-postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: keycloak-postgres
+  template:
+    metadata:
+      labels:
+        app: keycloak-postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:18-alpine
+          ports:
+            - containerPort: 5432
+              name: postgres
+          env:
+            - name: POSTGRES_DB
+              value: keycloak
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: POSTGRES_PASSWORD
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - postgres
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - postgres
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi

--- a/k8s/base/keycloak/deployment.yaml
+++ b/k8s/base/keycloak/deployment.yaml
@@ -102,6 +102,24 @@ spec:
                 configMapKeyRef:
                   name: foodies-config
                   key: RABBITMQ_QUEUE
+            - name: KC_DB
+              value: postgres
+            - name: KC_DB_URL_HOST
+              value: keycloak-postgres
+            - name: KC_DB_URL_PORT
+              value: "5432"
+            - name: KC_DB_URL_DATABASE
+              value: keycloak
+            - name: KC_DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: POSTGRES_USER
+            - name: KC_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: POSTGRES_PASSWORD
           ports:
             - containerPort: 8000
               name: http

--- a/k8s/base/keycloak/kustomization.yaml
+++ b/k8s/base/keycloak/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - keycloak.yaml
   - deployment.yaml
+  - database.yaml
 
 configMapGenerator:
   - name: keycloak-config

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -31,6 +31,8 @@ configMapGenerator:
 
 secretGenerator:
   - name: keycloak-admin
+    options:
+      disableNameSuffixHash: true
     literals:
       - KC_BOOTSTRAP_ADMIN_USERNAME=admin
       - KC_BOOTSTRAP_ADMIN_PASSWORD=admin

--- a/k8s/overlays/dev/keycloak-config-job.yaml
+++ b/k8s/overlays/dev/keycloak-config-job.yaml
@@ -99,13 +99,82 @@ spec:
                   -s 'description=Regular user with standard permissions'
               fi
 
+              echo "Configuring 'foodies-audience' client scope..."
+              SCOPE_ID=$(/opt/keycloak/bin/kcadm.sh get client-scopes -r foodies-keycloak 2>/dev/null | grep -B5 '"name" *: *"foodies-audience"' | grep -o '"id" *: *"[^"]*"' | head -1 | sed 's/.*"id" *: *"\([^"]*\)".*/\1/' || echo "")
+
+              if [ -n "$SCOPE_ID" ]; then
+                echo "Client scope 'foodies-audience' already exists (ID: $SCOPE_ID), updating..."
+                cat > /tmp/client-scope.json << 'EOF'
+              {
+                "name": "foodies-audience",
+                "description": "Adds foodies audience to tokens for API access",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "false",
+                  "display.on.consent.screen": "false"
+                }
+              }
+              EOF
+                /opt/keycloak/bin/kcadm.sh update client-scopes/$SCOPE_ID -r foodies-keycloak -f /tmp/client-scope.json
+              else
+                echo "Creating client scope 'foodies-audience'..."
+                cat > /tmp/client-scope.json << 'EOF'
+              {
+                "name": "foodies-audience",
+                "description": "Adds foodies audience to tokens for API access",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "false",
+                  "display.on.consent.screen": "false"
+                }
+              }
+              EOF
+                /opt/keycloak/bin/kcadm.sh create client-scopes -r foodies-keycloak -f /tmp/client-scope.json
+                SCOPE_ID=$(/opt/keycloak/bin/kcadm.sh get client-scopes -r foodies-keycloak 2>/dev/null | grep -B5 '"name" *: *"foodies-audience"' | grep -o '"id" *: *"[^"]*"' | head -1 | sed 's/.*"id" *: *"\([^"]*\)".*/\1/')
+              fi
+
+              echo "Configuring audience mapper in 'foodies-audience' scope..."
+              MAPPER_ID=$(/opt/keycloak/bin/kcadm.sh get client-scopes/$SCOPE_ID/protocol-mappers/models -r foodies-keycloak 2>/dev/null | grep -B5 '"name" *: *"audience-mapper"' | grep -o '"id" *: *"[^"]*"' | head -1 | sed 's/.*"id" *: *"\([^"]*\)".*/\1/' || echo "")
+
+              if [ -n "$MAPPER_ID" ]; then
+                echo "Audience mapper already exists in scope, updating..."
+                cat > /tmp/audience-mapper.json << 'EOF'
+              {
+                "name": "audience-mapper",
+                "protocol": "openid-connect",
+                "protocolMapper": "oidc-audience-mapper",
+                "consentRequired": false,
+                "config": {
+                  "included.client.audience": "foodies",
+                  "id.token.claim": "true",
+                  "access.token.claim": "true"
+                }
+              }
+              EOF
+                /opt/keycloak/bin/kcadm.sh update client-scopes/$SCOPE_ID/protocol-mappers/models/$MAPPER_ID -r foodies-keycloak -f /tmp/audience-mapper.json
+              else
+                echo "Creating audience mapper in scope..."
+                cat > /tmp/audience-mapper.json << 'EOF'
+              {
+                "name": "audience-mapper",
+                "protocol": "openid-connect",
+                "protocolMapper": "oidc-audience-mapper",
+                "consentRequired": false,
+                "config": {
+                  "included.client.audience": "foodies",
+                  "id.token.claim": "true",
+                  "access.token.claim": "true"
+                }
+              }
+              EOF
+                /opt/keycloak/bin/kcadm.sh create client-scopes/$SCOPE_ID/protocol-mappers/models -r foodies-keycloak -f /tmp/audience-mapper.json
+              fi
+
               echo "Checking if client 'foodies' exists..."
-              # Use query parameter for more reliable lookup
               CLIENT_ID=$(/opt/keycloak/bin/kcadm.sh get clients -r foodies-keycloak -q clientId=foodies --fields id 2>/dev/null | grep -o '"id" *: *"[^"]*"' | head -1 | sed 's/.*"id" *: *"\([^"]*\)".*/\1/' || echo "")
 
               if [ -n "$CLIENT_ID" ]; then
                 echo "Client 'foodies' already exists (ID: $CLIENT_ID), updating..."
-                # Use JSON file for proper array and attribute handling
                 cat > /tmp/client-update.json << 'EOF'
               {
                 "clientId": "foodies",
@@ -136,7 +205,11 @@ spec:
               }
               EOF
                 /opt/keycloak/bin/kcadm.sh create clients -r foodies-keycloak -f /tmp/client-create.json
+                CLIENT_ID=$(/opt/keycloak/bin/kcadm.sh get clients -r foodies-keycloak -q clientId=foodies --fields id 2>/dev/null | grep -o '"id" *: *"[^"]*"' | head -1 | sed 's/.*"id" *: *"\([^"]*\)".*/\1/')
               fi
+
+              echo "Assigning 'foodies-audience' scope to client as default scope..."
+              /opt/keycloak/bin/kcadm.sh update clients/$CLIENT_ID/default-client-scopes/$SCOPE_ID -r foodies-keycloak 2>/dev/null || echo "Scope already assigned or assignment created"
 
               echo "Checking if user 'food3_lover' exists..."
               # Use query parameter for more reliable lookup


### PR DESCRIPTION
## Summary
This PR adds PostgreSQL database persistence for Keycloak to ensure authentication data survives pod restarts.
- Add PostgreSQL StatefulSet for Keycloak data storage (`k8s/base/keycloak/database.yaml`)
- Update Keycloak deployment with database configuration environment variables
- Add foodies-audience client scope with audience mapper for proper JWT validation
- Update kustomization files to include Keycloak database resources
- Disable name suffix hash for keycloak-admin secret
- Persistent Keycloak configuration (users, clients, realms)
- Proper audience claims in JWT tokens for service authentication
- Production-ready Keycloak setup with database backend