### PR TITLE
Enhance test configurations and refactor imports

### DIFF
--- a/keycloak-rabbitmq-publisher/build.gradle.kts
+++ b/keycloak-rabbitmq-publisher/build.gradle.kts
@@ -48,7 +48,8 @@ tasks {
         inputs.dir(rootProject.projectDir.resolve("keycloak"))
 
         workingDir(rootProject.projectDir)
-        commandLine("docker", "build", "--build-arg", "JAR_VERSION=${project.version}",
+        commandLine(
+            "docker", "build", "--build-arg", "JAR_VERSION=${project.version}",
             "-t", imageTag,
             "-f", "keycloak/Dockerfile",
             "."
@@ -77,22 +78,22 @@ tasks {
     }
 
     withType<Test>().configureEach {
-//        dependsOn(publishImageToLocalRegistry)
+        dependsOn(publishImageToLocalRegistry)
         dependsOn("installPlaywrightBrowsers")
         systemProperty("keycloak.image", imageTag)
         systemProperty("headless", project.findProperty("headless") ?: "true")
         systemProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager")
     }
-}
 
-    tasks.withType<JavaExec>().configureEach {
+    withType<JavaExec>().configureEach {
         systemProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager")
     }
 
-    tasks.register<JavaExec>("installPlaywrightBrowsers") {
-    group = "playwright"
-    description = "Installs Playwright browsers"
-    mainClass.set("com.microsoft.playwright.CLI")
-    classpath = sourceSets["test"].runtimeClasspath
-    args = listOf("install", "chromium", "--with-deps")
+    register<JavaExec>("installPlaywrightBrowsers") {
+        group = "playwright"
+        description = "Installs Playwright browsers"
+        mainClass.set("com.microsoft.playwright.CLI")
+        classpath = sourceSets["test"].runtimeClasspath
+        args = listOf("install", "chromium", "--with-deps")
+    }
 }

--- a/keycloak-rabbitmq-publisher/src/test/kotlin/io/ktor/foodies/keycloak/KeycloakContainerSpec.kt
+++ b/keycloak-rabbitmq-publisher/src/test/kotlin/io/ktor/foodies/keycloak/KeycloakContainerSpec.kt
@@ -1,9 +1,8 @@
 package io.ktor.foodies.keycloak
 
-import com.foodies.e2e.e2eSuite
-import com.foodies.e2e.keycloak
-import com.foodies.e2e.page
-import com.foodies.e2e.rabbit
+import com.microsoft.playwright.Page
+import com.microsoft.playwright.options.AriaRole
+import com.microsoft.playwright.options.LoadState
 import de.infix.testBalloon.framework.core.TestConfig
 import de.infix.testBalloon.framework.core.testScope
 import io.ktor.foodies.server.test.channel
@@ -15,14 +14,13 @@ import kotlin.time.Duration.Companion.seconds
 val keyCloakSpec by e2eSuite(testConfig = TestConfig.testScope(true, timeout = 3.minutes)) {
     test("should publish REGISTER event to RabbitMQ") {
         val authServerUrl = keycloak().authServerUrl
-        assertNotNull(authServerUrl)
 
-        val registrationUrl = "$authServerUrl/realms/foodies-keycloak/protocol/openid-connect/registrations?client_id=foodies&response_type=code&redirect_uri=http://localhost:8080/oauth/callback"
+        val registrationUrl =
+            "$authServerUrl/realms/foodies-keycloak/protocol/openid-connect/registrations?client_id=foodies&response_type=code&redirect_uri=http://localhost:8080/oauth/callback"
 
         page().navigate(registrationUrl)
-        page().waitForLoadState(com.microsoft.playwright.options.LoadState.NETWORKIDLE)
+        page().waitForLoadState(LoadState.NETWORKIDLE)
 
-        // Fill out registration form
         val timestamp = System.currentTimeMillis()
         val username = "test_user_$timestamp"
         val email = "test_user_$timestamp@example.com"
@@ -34,10 +32,8 @@ val keyCloakSpec by e2eSuite(testConfig = TestConfig.testScope(true, timeout = 3
         page().locator("#firstName").fill("Test")
         page().locator("#lastName").fill("User")
 
-        // Submit registration
-        page().getByRole(com.microsoft.playwright.options.AriaRole.BUTTON, com.microsoft.playwright.Page.GetByRoleOptions().setName("Register")).click()
+        page().getByRole(AriaRole.BUTTON, Page.GetByRoleOptions().setName("Register")).click()
 
-        // Check that the REGISTER event is received in RabbitMQ
         rabbit().connectionFactory().channel { channel ->
             val queueName = "profile.registration"
             channel.queueDeclare(queueName, true, false, false, null)

--- a/keycloak-rabbitmq-publisher/src/test/kotlin/io/ktor/foodies/keycloak/TestSyntax.kt
+++ b/keycloak-rabbitmq-publisher/src/test/kotlin/io/ktor/foodies/keycloak/TestSyntax.kt
@@ -1,4 +1,4 @@
-package com.foodies.e2e
+package io.ktor.foodies.keycloak
 
 import com.microsoft.playwright.Browser
 import com.microsoft.playwright.BrowserType
@@ -14,10 +14,8 @@ import de.infix.testBalloon.framework.shared.TestElementName
 import de.infix.testBalloon.framework.shared.TestRegistering
 import io.ktor.foodies.server.test.RabbitContainer
 import io.ktor.foodies.server.test.rabbitContainer
-import org.keycloak.representations.idm.ClientRepresentation
 import org.testcontainers.Testcontainers
 import org.testcontainers.utility.MountableFile
-import java.nio.file.Files
 import java.nio.file.Paths
 
 fun TestSuite.keycloak(rabbit: TestFixture<RabbitContainer>) = testFixture {
@@ -29,7 +27,6 @@ fun TestSuite.keycloak(rabbit: TestFixture<RabbitContainer>) = testFixture {
         withEnv("RABBITMQ_PORT", rabbit.amqpPort.toString())
         withEnv("RABBITMQ_USERNAME", rabbit.adminUsername)
         withEnv("RABBITMQ_PASSWORD", rabbit.adminPassword)
-
         val realmFile = Paths.get("../k8s/base/keycloak/realm-common.json").toAbsolutePath().normalize()
         withCopyFileToContainer(MountableFile.forHostPath(realmFile), "/opt/keycloak/data/import/realm.json")
         start()
@@ -68,7 +65,6 @@ fun e2eSuite(
     @TestDisplayName displayName: String = name,
     testConfig: TestConfig = TestConfig,
     browserType: AppBrowserType = AppBrowserType.WEBKIT,
-    authenticated: Boolean = true,
     content: context(E2EContext) TestSuite.() -> Unit
 ): Lazy<TestSuite> = testSuite(name, displayName, testConfig) {
     val rabbit = rabbitContainer()

--- a/webapp/src/test/kotlin/io/ktor/foodies/server/HealthCheckSpec.kt
+++ b/webapp/src/test/kotlin/io/ktor/foodies/server/HealthCheckSpec.kt
@@ -1,13 +1,19 @@
 package io.ktor.foodies.server
 
+import de.infix.testBalloon.framework.core.TestConfig
+import de.infix.testBalloon.framework.core.testScope
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
 import io.ktor.foodies.server.test.ctxSuite
 import io.ktor.http.HttpStatusCode
 import kotlin.test.assertEquals
 import kotlin.test.assertContains
+import kotlin.time.Duration.Companion.minutes
 
-val healthCheckSpec by ctxSuite(context = { serviceContext() }) {
+val healthCheckSpec by ctxSuite(
+    context = { serviceContext() },
+    testConfig = TestConfig.testScope(true, timeout = 2.minutes) // cold CI start to pull & start keycloak
+) {
 
     testWebAppService("startup probe returns 200 OK") {
         startApplication()

--- a/webapp/src/test/kotlin/io/ktor/foodies/server/TestSyntax.kt
+++ b/webapp/src/test/kotlin/io/ktor/foodies/server/TestSyntax.kt
@@ -30,7 +30,7 @@ data class ServiceContext(
 fun TestSuite.serviceContext(): ServiceContext {
     val fixture = testFixture {
         val redis = RedisContainer("redis:7-alpine")
-        val keycloak = KeycloakContainer("quay.io/keycloak/keycloak:26.5.0").apply {
+        val keycloak = KeycloakContainer("quay.io/keycloak/keycloak:26.5.2").apply {
             val realmFile = Paths.get("../k8s/base/keycloak/realm-common.json").toAbsolutePath().normalize()
             withCopyFileToContainer(MountableFile.forHostPath(realmFile), "/opt/keycloak/data/import/realm.json")
         }


### PR DESCRIPTION
- Updated HealthCheckSpec and KeycloakContainerSpec with new timeout configurations and simplified imports.
- Refactored package names in Keycloak test syntax to align with the project structure.
- Upgraded Keycloak container version to `26.5.2`.
- Adjusted Docker build command structure and enabled Playwright browser installation in Test tasks.